### PR TITLE
Repair jobs API

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@ require 'vendor/autoload.php';
 
 $app = new \Slim\Slim(array(
     // change to 'development' for testing
-    'mode' => 'production'
+    'mode' => 'development'
 ));
 
 // Only invoked if mode is "production"
@@ -80,24 +80,62 @@ $app->get('/api', function () use ($app) {
 
 // industry example
 $app->get('/industries', function () use ($app) {
-    $res = executeSql("SELECT DISTINCT Id, Name FROM industries ORDER BY Name");
-    foreach($res as $row){
-        echo "<a href=\"#\" onclick=\"return loadJob(";
-        echo $row->Id;
-        echo ")\" class=\"selectable_result\">" . $row->Name . "</a>";
-        echo "<br />";
+    $industries = executeSql('
+		SELECT DISTINCT
+			Id AS id,
+			Name AS name
+		FROM industries
+		ORDER BY Name
+	');
+
+	$result = [];
+
+    foreach($industries as $industry){
+        $result[] = [
+			'id' => $industry->id,
+			'name' => $industry->name
+		];
     };
 
+	$app->response->headers->set('Content-Type', 'application/json');
+	$app->response->write(json_encode($result));
 });
 
 // jobs example
 $app->get('/jobs', function () use ($app) {
-    $res = empty($_GET) ? executeSql("SELECT DISTINCT Name FROM occupations ORDER BY Name") : executeSql("SELECT DISTINCT Name FROM occupations WHERE IndustryId = :industry ORDER BY Name", array(':industry' => intval($_GET['industry'])));
-    foreach($res as $entry) {        
-        $row = $entry->Name;
-        echo "<a href=\"#\" onclick=\"return loadJobDetails('$row')\" class=\"selectable_result\">$row</a>";
-        echo "<br>";    
+	if (isset($_GET['industry']) && strlen(trim($_GET['industry'])) > 0) {
+		$occupations = executeSql(
+			'
+				SELECT
+					DISTINCT Name AS name,
+					Id AS id
+				FROM occupations
+				WHERE IndustryId = :industry
+				ORDER BY Name
+			',
+			['industry' => intval($_GET['industry'])]
+		);
+	} else {
+		$occupations = executeSql('
+			SELECT
+				DISTINCT Name AS name,
+				Id AS id
+			FROM occupations
+			ORDER BY Name
+		');
+	}
+
+	$result = [];
+
+    foreach($occupations as $occupation) {
+        $result[] = [
+			'id' => $occupation->id,
+			'name' => $occupation->name
+		];
     };
+
+	$app->response->headers->set('Content-Type', 'application/json');
+	$app->response->write(json_encode($result));
 });
 
 // jobs example
@@ -134,24 +172,59 @@ $app->get('/search/:searchQuery', function($searchQuery) use($app) {
     $result = array('industries' => [], 'jobs' => []);
 
     // find matching industries
-    $query = "SELECT Id, Name FROM industries WHERE MATCH(Name) AGAINST ( '$searchQuery' )";
-    $res = executeSql($query);
-    $industries = [];
-    foreach($res as $industry) {
-        $industries[$industry->Id] = array( 'id' => $industry->Id, 'name' => $industry->Name);
+    $industries = executeSql(
+		'
+			SELECT
+				Id AS id,
+				Name AS name
+			FROM industries
+			WHERE MATCH(Name) AGAINST ( :searchQuery )
+		',
+		['searchQuery' => $searchQuery]
+	);
+
+    $resultIndustries = [];
+
+    foreach($industries as $industry) {
+		$resultIndustries[$industry->id] = [
+			'id' => $industry->id,
+			'name' => $industry->name
+		];
     }
 
     // find matching jobs
-    $jobs = [];
-    $query = "SELECT DISTINCT i.Id as IndustryId, i.Name as IndustryName, o.Name as JobName FROM occupations o, industries i WHERE o.IndustryId = i.Id AND MATCH(o.Description, o.Name) AGAINST ( '$searchQuery' )";
-    $res = executeSql($query);
-    foreach($res as $job) {
-        array_push($jobs, array( 'name' => $job->JobName));
+	$jobs = executeSql(
+		'
+			SELECT DISTINCT
+				i.Id as industryId,
+				i.Name as industryName,
+				o.Name as jobName
+			FROM occupations o,
+				industries i
+			WHERE o.IndustryId = i.Id
+				AND MATCH(o.Description, o.Name) AGAINST ( :searchQuery )
+		',
+		['searchQuery' => $searchQuery]
+	);
+
+    $resultJobs = [];
+
+    foreach($jobs as $job) {
+		$resultJobs[] = [
+			'name' => $job->jobName
+		];
+
         // add job industry to industries list
-        $industries[$job->IndustryId] = array('id' => $job->IndustryId, 'name' => $job->IndustryName);
+		$resultIndustries[$job->industryId] = [
+			'id' => $job->industryId,
+			'name' => $job->industryName
+		];
     }
 
-    $result = array('industries' => array_values($industries), 'jobs' => $jobs);
+    $result = [
+		'industries' => array_values($resultIndustries),
+		'jobs' => $resultJobs
+	];
 
     $app->response->headers->set('Content-Type', 'application/json');
     $app->response->write(json_encode($result));

--- a/js/job-selection.js
+++ b/js/job-selection.js
@@ -1,7 +1,11 @@
 //Loads jobs that correspong to the users selection of an industry
 function loadJob(industry) {
-	$.ajax({url:"/jobs?industry="+industry,success:function(result){
-			$("#box2 .resultsbox").html(result);
+	$.ajax({url:"/jobs?industry="+industry,success:function(result) {
+		html = '';
+		$.each(result, function(i, item) {
+			html += "<a href='#' onclick=\"return loadJobDetails('" + item.name + "')\" class=\"selectable_result\">" + item.name + "</a><br/>";
+		});
+		$("#box2 .resultsbox").html(html);
 	}});
 }
 
@@ -49,12 +53,20 @@ $(document).ready(function(){
 
 $(document).ready(function(){
 	//Pulls all industries on page load
-	$.ajax({url:"/jobs",success:function(result){
-		$("#box2 .resultsbox").html(result);
+	$.ajax({url:"/jobs",success:function(result) {
+		html = '';
+		$.each(result, function(i, item) {
+			html += "<a href='#' onclick=\"return loadJobDetails('" + item.name + "')\" class=\"selectable_result\">" + item.name + "</a><br/>";
+		});
+		$("#box2 .resultsbox").html(html);
 	}});
 	//Pulls all jobs on page load
 	$.ajax({url:"/industries",success:function(result){
-		$("#box1 .resultsbox").html(result);
+		html = '';
+		$.each(result, function(i, item) {
+			html += "<a href='#' onclick=\"return loadJob('" + item.id + "')\" class=\"selectable_result\">" + item.name + "</a><br/>";
+		});
+		$("#box1 .resultsbox").html(html);
 	}});
 	//Changes job results based on education level selection from user
 	$('input[name="education[]"]').change(function(){


### PR DESCRIPTION
Fix #22

Hey guys, I saw an issue about jobs API so I have repaired it.

I have also done a few changes:
- Somewhere API returns HTML and somewhere JSON. The correct way is JSON so have edited APIs to return JSON and adjusted Javascript file to accept JSON format.
- I have seen a really fatal error. There was a SQL query in search API which injected a value directly from URL query parameters to the SQL query string variable. It was a nice place where we could be attacked by SQL injection. For example try to search API send request with "' ); DROP DATABASE blueeconomics; SELECT CONCAT(0, '" and guess what has happened :-) Who doesn't know SQL, it REMOVE whole database. (The exact example of query is "/search/%27%20)%3B%20DROP%20DATABASE%20blueeconomics%3B%20SELECT%20CONCAT(0%2C%20%27". So I have improved it.

I have a question for job_description API. Why does this API get as value a name of job instead of job's id?

Please do code review if you do and let me know. Thanks
